### PR TITLE
Update PrefabInPrefab.cs

### DIFF
--- a/Assets/PrefabInPrefab/Scripts/PrefabInPrefab.cs
+++ b/Assets/PrefabInPrefab/Scripts/PrefabInPrefab.cs
@@ -253,7 +253,7 @@ public class PrefabInPrefab : MonoBehaviour
 		foreach(var nextTarget in ((GameObject)target.prefab).GetComponentsInChildren<PrefabInPrefab>(true))
 		{
 			if(nextTarget == this) continue;
-			if(CheckCircularReference(nextTarget, usedPrefabs)) return true;
+			if(CheckCircularReference(nextTarget, new List<int>(usedPrefabs))) return true;
 		}
 
 		return false;


### PR DESCRIPTION
By creating a copy of the list before checking for duplicates you allow an object to have several of the same type of Prefabs.
This searches every branch for duplicates but allows different branches to contain similar objects as long as there is no circular reference.
## Examples: ( All objects are instances of PrefabInPrefab )

Object A has 2 Object B's 
Object B has unrelated Objects Z
## -> Valid, passes with new change (it used to fail)

Object C has Object D
Object D has Object C
-> Invalid, fails like it should ( this was correct before and is still correct now)
